### PR TITLE
add middleware for sentry

### DIFF
--- a/server/sentryware.go
+++ b/server/sentryware.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"runtime"
+
+	"github.com/getsentry/raven-go"
+	"github.com/mijia/sweb/log"
+	"golang.org/x/net/context"
+)
+
+// SentryRecoveryWare is the recovery middleware which can cover the panic situation.
+// If a sentry client is in the context, it will send the panic to the sentry server.
+type SentryRecoveryWare struct {
+	RecoveryWare
+}
+
+// ServeHTTP implements the Middleware interface, just recover from the panic.
+// Would send information to the sentry server.
+func (m *SentryRecoveryWare) ServeHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler) context.Context {
+	defer func() {
+		if err := recover(); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			stack := make([]byte, m.stackSize)
+			stack = stack[:runtime.Stack(stack, m.stackAll)]
+			log.Errorf("PANIC: %s\n%s", err, stack)
+			if cli, ok := ctx.Value("sentryclient").(*raven.Client); ok {
+				cli.CaptureError(errors.New(fmt.Sprint(err)), nil)
+			}
+		}
+	}()
+
+	return next(ctx, w, r)
+}
+
+// NewSentryRecoveryWare returns a new recovery middleware similar as RecoveryWare but can send messages to the sentry server.
+func NewSentryRecoveryWare(flags ...bool) Middleware {
+	stackFlags := []bool{false, false}
+	for i := range flags {
+		if i >= len(stackFlags) {
+			break
+		}
+		stackFlags[i] = flags[i]
+	}
+	return &SentryRecoveryWare{
+		RecoveryWare{
+			printStack: stackFlags[0],
+			stackAll:   stackFlags[1],
+			stackSize:  1024 * 8,
+		},
+	}
+}


### PR DESCRIPTION
Use context.Context‘s parameter "sentryclient" as raven.Client，then send an error message when getting a panic. For more information, see github.com/getsentry/raven-go